### PR TITLE
systemd: ignore the exit code of systemd-detect-virt for memory hot-add

### DIFF
--- a/80-hotplug-cpu-mem.rules
+++ b/80-hotplug-cpu-mem.rules
@@ -14,7 +14,7 @@ SUBSYSTEM=="cpu", ACTION=="add", TEST=="online", ATTR{online}=="0", ATTR{online}
 # lot of shortcomings anyways (tmpfs mounted by other processes, mount
 # namespaces, ...)
 #
-SUBSYSTEM=="memory", ACTION=="add", PROGRAM=="/usr/bin/systemd-detect-virt", RESULT!="zvm", ATTR{state}=="offline", \
+SUBSYSTEM=="memory", ACTION=="add", PROGRAM=="/bin/sh -c '/usr/bin/systemd-detect-virt || :'", RESULT!="zvm", ATTR{state}=="offline", \
   ATTR{state}="online", \
   RUN+="/bin/sh -c ' \
     while read src dst fs opts unused; do \


### PR DESCRIPTION
In 80-hotplug-cpu-mem.rules on SLE12-SP3, there have a memory hot-add rule
uses systemd-detect-virt to detect non-zvm environment. The
systemd-detect-virt returns exit failure code when it detected _none_ state.
The exit failure code causes that the hot-add memory block can not be set to
online.

This patch follows Franck Bui's suggestion on sytstemd upstream to
ignore exit code:
        https://www.spinics.net/lists/systemd-devel/msg00341.html