### PR TITLE
80-hotplug-cpu-mem: fix 'invalid substitution type' warning (boo#1154…

### DIFF
--- a/80-hotplug-cpu-mem.rules
+++ b/80-hotplug-cpu-mem.rules
@@ -18,7 +18,7 @@ SUBSYSTEM=="memory", ACTION=="add", PROGRAM=="/usr/bin/uname -m", RESULT!="s390x
   ATTR{state}="online", \
   RUN+="/bin/sh -c ' \
     while read src dst fs opts unused; do \
-      case $fs in \
-      tmpfs)  mount -o remount \"$dst\" ;; \
+      case $$fs in \
+      tmpfs)  mount -o remount \"$$dst\" ;; \
       esac \
     done </proc/self/mounts"


### PR DESCRIPTION
…655)

'$' needs to be escaped (by another '$') if not used for performing a
udev substitution.