### PR TITLE
60-io-scheduler.rules: Modify rules for BLK-MQ

### DIFF
--- a/60-io-scheduler.rules
+++ b/60-io-scheduler.rules
@@ -10,10 +10,10 @@ ENV{elevator}=="?*", GOTO="scheduler_end"
 # Determine if BLK-MQ is enabled
 TEST=="%S%p/mq", ENV{.IS_MQ}="1"
 
-# MQ: BFQ scheduler for HDD
-ENV{.IS_MQ}=="1", ATTR{queue/rotational}!="0", ATTR{queue/scheduler}="bfq"
-# MQ: deadline scheduler for SSD
-ENV{.IS_MQ}=="1", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="mq-deadline"
+# MQ: BFQ scheduler for HDD (other than host-managed SMR)
+ENV{.IS_MQ}=="1", ATTR{queue/rotational}!="0", ATTR{queue/zoned}!="host-managed", ATTR{queue/scheduler}="bfq"
+# MQ: BFQ scheduler for SSD
+ENV{.IS_MQ}=="1", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="bfq"
 
 # Non-MQ: CFQ scheduler for HDD
 ENV{.IS_MQ}!="1", ATTR{queue/rotational}!="0", ATTR{queue/scheduler}="cfq"


### PR DESCRIPTION
Don't try to select BFQ for host-managed SMR drives.
Select BFQ also for SSDs (rationale: bsc#1134353).

Signed-off-by: Andreas Herrmann <aherrmann@suse.com>