### PR TITLE
Fixes for IO scheduler rules

### DIFF
--- a/60-io-scheduler.rules
+++ b/60-io-scheduler.rules
@@ -1,5 +1,11 @@
 # Set optimal IO schedulers for HDD and SSD
 
+# ## DO NOT EDIT. ##
+# To modify the rules, copy this file to /etc/udev/rules.d/60-io-scheduler.rules
+# and edit the copy.
+# Please read the section "Tuning I/O performance" in the System Analysis and Tuning Guide
+# from the SUSE Documentation.
+
 SUBSYSTEM!="block", GOTO="scheduler_end"
 ACTION!="add", KERNEL!="dm-*", GOTO="scheduler_end"
 ACTION!="change", KERNEL=="dm-*", GOTO="scheduler_end"
@@ -8,11 +14,23 @@ ATTR{queue/scheduler}=="none", GOTO="scheduler_end"
 # keep our hands off zoned devices, the kernel auto-configures them
 ATTR{queue/zoned}!="none", GOTO="scheduler_end"
 
-# BFQ scheduler for HDD
-ATTR{queue/rotational}!="0", ATTR{queue/scheduler}="bfq"
+# --- EDIT BELOW HERE after copying to /etc/udev/rules.d ---
 
-# mq-deadline is the default anyway
-# ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="mq-deadline"
+# 1. BFQ scheduler for single-queue HDD (uncomment if you comment out rule 2.+4.)
+# ATTR{queue/rotational}!="0", TEST!="%S%p/mq/1", ATTR{queue/scheduler}="bfq", GOTO="scheduler_end"
 
+# 2. BFQ scheduler for every HDD (comment out if you uncomment rule 4.)
+ATTR{queue/rotational}!="0", ATTR{queue/scheduler}="bfq", GOTO="scheduler_end"
+
+# 3. For "real" multiqueue devices, the kernel defaults to no IO scheduling
+# Uncomment this (and select your scheduler) if you need an IO scheduler for them
+# TEST=="%S%p/mq/1", ATTR{queue/scheduler}="kyber", GOTO="scheduler_end"
+
+# 4. BFQ scheduler for every device (uncomment if you need ionice or blk-cgroup features)
+# ATTR{queue/scheduler}="bfq", GOTO="scheduler_end"
+
+# 5. mq-deadline is the kernel default for devices with just one hardware queue
+# ATTR{queue/scheduler}="mq-deadline"
+
+# --- EDIT ABOVE HERE after copying to /etc/udev/rules.d ---
 LABEL="scheduler_end"
-

--- a/60-io-scheduler.rules
+++ b/60-io-scheduler.rules
@@ -5,6 +5,8 @@ ACTION!="add", KERNEL!="dm-*", GOTO="scheduler_end"
 ACTION!="change", KERNEL=="dm-*", GOTO="scheduler_end"
 # "none" with no brackets means scheduler isn't configurable
 ATTR{queue/scheduler}=="none", GOTO="scheduler_end"
+# keep our hands off zoned devices, the kernel auto-configures them
+ATTR{queue/zoned}!="none", GOTO="scheduler_end"
 
 # Do not change scheduler if `elevator` cmdline parameter is set
 IMPORT{cmdline}="elevator"

--- a/60-io-scheduler.rules
+++ b/60-io-scheduler.rules
@@ -8,22 +8,11 @@ ATTR{queue/scheduler}=="none", GOTO="scheduler_end"
 # keep our hands off zoned devices, the kernel auto-configures them
 ATTR{queue/zoned}!="none", GOTO="scheduler_end"
 
-# Do not change scheduler if `elevator` cmdline parameter is set
-IMPORT{cmdline}="elevator"
-ENV{elevator}=="?*", GOTO="scheduler_end"
+# BFQ scheduler for HDD
+ATTR{queue/rotational}!="0", ATTR{queue/scheduler}="bfq"
 
-# Determine if BLK-MQ is enabled
-TEST=="%S%p/mq", ENV{.IS_MQ}="1"
-
-# MQ: BFQ scheduler for HDD
-ENV{.IS_MQ}=="1", ATTR{queue/rotational}!="0", ATTR{queue/scheduler}="bfq"
-# MQ: deadline scheduler for SSD
-ENV{.IS_MQ}=="1", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="mq-deadline"
-
-# Non-MQ: CFQ scheduler for HDD
-ENV{.IS_MQ}!="1", ATTR{queue/rotational}!="0", ATTR{queue/scheduler}="cfq"
-# Non-MQ: deadline scheduler for SSD
-ENV{.IS_MQ}!="1", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="deadline"
+# mq-deadline is the default anyway
+# ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="mq-deadline"
 
 LABEL="scheduler_end"
 

--- a/60-io-scheduler.rules
+++ b/60-io-scheduler.rules
@@ -3,6 +3,8 @@
 SUBSYSTEM!="block", GOTO="scheduler_end"
 ACTION!="add", KERNEL!="dm-*", GOTO="scheduler_end"
 ACTION!="change", KERNEL=="dm-*", GOTO="scheduler_end"
+# "none" with no brackets means scheduler isn't configurable
+ATTR{queue/scheduler}=="none", GOTO="scheduler_end"
 
 # Do not change scheduler if `elevator` cmdline parameter is set
 IMPORT{cmdline}="elevator"

--- a/60-io-scheduler.rules
+++ b/60-io-scheduler.rules
@@ -1,7 +1,8 @@
 # Set optimal IO schedulers for HDD and SSD
 
-ACTION!="add", GOTO="scheduler_end"
 SUBSYSTEM!="block", GOTO="scheduler_end"
+ACTION!="add", KERNEL!="dm-*", GOTO="scheduler_end"
+ACTION!="change", KERNEL=="dm-*", GOTO="scheduler_end"
 
 # Do not change scheduler if `elevator` cmdline parameter is set
 IMPORT{cmdline}="elevator"


### PR DESCRIPTION
See bsc#1188713. The first two patches are bug fixes which should be applied to older distros with 4.12 kernel, too. The last patch is for 5.x kernels only.